### PR TITLE
Fix av menybuggen

### DIFF
--- a/Webbsida/assets/css/media_queries.css
+++ b/Webbsida/assets/css/media_queries.css
@@ -1,9 +1,20 @@
+/* Media Query for Screen max width-640(px) */
+@media (min-width:640px) {
+    #menu_ul{
+        display: block !important;
+    }
+}
+
 /* Media Query for Tablet 640-501(px) */
 @media (max-width:640px) and (min-width:501px) {
     /* Header/Menu */
     #header img {
         height: 3.5em;
         padding: 0.5em;
+    }
+    
+    #menu_ul{
+        display: block !important;
     }
     
     nav {


### PR DESCRIPTION
Lösningen var att först lägga till en media query för storskärm, sedan
under den lägga till:

#menu_ul{
display: block !important;
}

Detta ser till så att "display: block" alltid skriver över "display
none" efter en viss bredd. Samma kodsnutt blev tilllagd i media queryn
för plattan för att menyn ska synas där med.